### PR TITLE
Compatibilità Python 3 + retrocompatibilità Python 2

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.dplay" name="Dplay" version="1.0.7" provider-name="NeverWise">
+<addon id="plugin.video.dplay" name="Dplay" version="1.0.7" provider-name="NeverWise, cttynul">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
     <import addon="script.module.neverwise" version="1.1.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.dplay" name="Dplay" version="1.0.6" provider-name="NeverWise">
+<addon id="plugin.video.dplay" name="Dplay" version="1.0.7" provider-name="NeverWise">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
     <import addon="script.module.neverwise" version="1.1.0"/>

--- a/default.py
+++ b/default.py
@@ -102,7 +102,10 @@ class Dplay(object):
             qlySetting = 1080
           else:
             qlySetting = 576
-          strms_names = re.findall('RESOLUTION=.+?x(.+?),.+?".+?"\s(.+)', stream.body)
+          try:
+            strms_names = re.findall(r'RESOLUTION=.+?x(.+?),.+?".+?"\s(.+)', stream.body)
+          except:
+            strms_names = re.findall(r'RESOLUTION=.+?x(.+?),.+?".+?"\s(.+)', stream.body.decode('utf-8'))
           items = []
           for qly, strm_name in strms_names:
             items.append(( abs(qlySetting - int(qly)), strm_name.strip() ))
@@ -143,8 +146,12 @@ class Dplay(object):
     headers = None
     if self._access_token != None:
       headers = { 'AccessToken' : self._access_token }
-      for key, value in default_headers.iteritems():
-        headers[key] = value
+      try:
+        for key, value in default_headers.iteritems():
+          headers[key] = value
+      except:
+        for key,value in default_headers.items():
+          headers[key] = value
     if headers == None:
       headers = default_headers
     if add_bearer:

--- a/default.py
+++ b/default.py
@@ -102,9 +102,9 @@ class Dplay(object):
             qlySetting = 1080
           else:
             qlySetting = 576
-          try:
+          try: # For python 2.x
             strms_names = re.findall(r'RESOLUTION=.+?x(.+?),.+?".+?"\s(.+)', stream.body)
-          except:
+          except: # For python 3.x
             strms_names = re.findall(r'RESOLUTION=.+?x(.+?),.+?".+?"\s(.+)', stream.body.decode('utf-8'))
           items = []
           for qly, strm_name in strms_names:
@@ -146,10 +146,10 @@ class Dplay(object):
     headers = None
     if self._access_token != None:
       headers = { 'AccessToken' : self._access_token }
-      try:
+      try: # For python 2.x
         for key, value in default_headers.iteritems():
           headers[key] = value
-      except:
+      except: # For python 3.x
         for key,value in default_headers.items():
           headers[key] = value
     if headers == None:


### PR DESCRIPTION
Come da titolo e come accennato nella pull request https://github.com/NeverWise/script.module.neverwise/pull/1

Colgo l'occasione di questa pull più che per mergare il codice in sé quanto per proporre una nuova feature (non disponibile nella mia branch in oggetto), ovvero l'eventualità di aggiungere i canali live editi Discovery fruibili sul sito web e sull'app ufficiale, ie:

![channel](https://i.imgur.com/pUPN86D.png)

Tuttavia i link di streaming di risposta al JSON sono con scadenza in timestamp (circa 24h dalla generazione dello stesso):
`https://sbshdlu5-lh.akamaihd.net/i/sbshdl_4@810998/master.m3u8?hdnts=st=1569426271~exp=1569512671~acl=/*~hmac=9975c0a120e5b518583d5db7d4a8db7a1f95de1b8f2252ffce5412fff6b4ccf3&mux_audio=true`

Aggirabile rimuovendo gli argomenti della chiamata dell'm3u8:
`https://sbshdlu5-lh.akamaihd.net/i/sbshdl_4@810998/master.m3u8`

La domanda è: Mantenere o meno l'eventuale timestamp di scadenza e, soprattutto, come gestire i canali Plus, esclusivi dei clienti paganti (Discovery Channel, Discovery Science ndr.) un semplice messaggio in cui si avvisa l'utente che il canale non sia fruibile?